### PR TITLE
コメント欄を拡張してコーヒーの記録を投稿できるようにする

### DIFF
--- a/www/wp-content/themes/yesterdays-coffee/assets/css/common.css
+++ b/www/wp-content/themes/yesterdays-coffee/assets/css/common.css
@@ -27,3 +27,32 @@ a {
   margin-bottom: 50px;
   padding-bottom: 50px;
 }
+
+.comment-form {
+  display: flex;
+  flex-direction: column;
+}
+.comment-form .logged-in-as {
+  order: 1;
+}
+.comment-form .comment-form-comment {
+  order: 3;
+  margin-top: 0;
+}
+.comment-form .acf-comment-fields {
+  order: 2;
+}
+.comment-form .form-submit {
+  order: 4;
+}
+.comment-form .comment-form-comment label {
+  display: block;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+.comment-form .comment-form-comment textarea {
+  width: 100%;
+}
+.comment-form .acf-input-append {
+  display: none;
+}

--- a/www/wp-content/themes/yesterdays-coffee/comments.php
+++ b/www/wp-content/themes/yesterdays-coffee/comments.php
@@ -54,6 +54,7 @@ if ( post_password_required() ) {
 				array(
 					'style'      => 'ol',
 					'short_ping' => true,
+					'callback' => 'yesterdays_coffee_comment'
 				)
 			);
 			?>

--- a/www/wp-content/themes/yesterdays-coffee/functions.php
+++ b/www/wp-content/themes/yesterdays-coffee/functions.php
@@ -172,3 +172,7 @@ if ( defined( 'JETPACK__VERSION' ) ) {
 	require get_template_directory() . '/inc/jetpack.php';
 }
 
+/**
+ * コメントフィールドの追加
+ */
+require get_template_directory() . '/inc/custom-comment.php';

--- a/www/wp-content/themes/yesterdays-coffee/inc/custom-comment.php
+++ b/www/wp-content/themes/yesterdays-coffee/inc/custom-comment.php
@@ -28,6 +28,73 @@ function yesterdays_coffee_comment($comment, $args, $depth) {
             <div class="comment-content">
                 <?php comment_text(); ?>
             </div><!-- .comment-content -->
+
+           <ul>
+            <?php
+            if ( get_field('amount-beans', $comment) ):
+              $amount_beans = get_field_object('amount-beans', $comment);
+            ?>
+              <li>
+              <span><?php echo $amount_beans['label']; ?></span>
+              <span><?php echo $amount_beans['value']; ?></span>
+              </li>
+            <?php endif; ?>
+            <?php
+            if ( get_field('grind-size', $comment) ):
+              $grind_size = get_field_object('grind-size', $comment);
+            ?>
+              <li>
+              <span><?php echo $grind_size['label']; ?></span>
+              <span><?php echo $grind_size['choices'][ $grind_size['value'] ]; ?></span>
+              </li>
+            <?php endif; ?>
+            <?php
+            if ( get_field('temperature', $comment) ):
+              $temperature = get_field_object('temperature', $comment);
+            ?>
+              <li>
+              <span><?php echo $temperature['label']; ?></span>
+              <span><?php echo $temperature['value']; ?></span>
+              </li>
+            <?php endif; ?>
+            <?php
+            if ( get_field('extraction-time', $comment) ):
+              $extraction_time = get_field_object('extraction-time', $comment);
+            ?>
+              <li>
+              <span><?php echo $extraction_time['label']; ?></span>
+              <span><?php echo $extraction_time['value']; ?></span>
+              </li>
+            <?php endif; ?>
+            <?php
+            if ( get_field('extraction-amount', $comment) ):
+              $extraction_amount = get_field_object('extraction-amount', $comment);
+            ?>
+              <li>
+              <span><?php echo $extraction_amount['label']; ?></span>
+              <span><?php echo $extraction_amount['value']; ?></span>
+              </li>
+            <?php endif; ?>
+            <?php
+            if ( get_field('input-amount', $comment) ):
+              $input_amount = get_field_object('input-amount', $comment);
+            ?>
+              <li>
+              <span><?php echo $input_amount['label']; ?></span>
+              <span><?php echo $input_amount['value']; ?></span>
+              </li>
+            <?php endif; ?>
+            <?php
+            if ( get_field('steaming-time', $comment) ):
+              $steaming_time = get_field_object('steaming-time', $comment);
+            ?>
+              <li>
+              <span><?php echo $steaming_time['label']; ?></span>
+              <span><?php echo $steaming_time['value']; ?></span>
+              </li>
+            <?php endif; ?>
+            </ul>
+
         </article><!-- .comment-body -->
   <?php
 }

--- a/www/wp-content/themes/yesterdays-coffee/inc/custom-comment.php
+++ b/www/wp-content/themes/yesterdays-coffee/inc/custom-comment.php
@@ -35,8 +35,9 @@ function yesterdays_coffee_comment($comment, $args, $depth) {
               $star = get_field_object('star', $comment);
             ?>
               <li>
-              <span><?php echo $star['label']; ?></span>
-              <span><?php echo $star['choices'][ $star['value'] ]; ?></span>
+              <span><?php echo esc_html($star['label']); ?></span>
+              <span><?php echo esc_html($star['choices'][ $star['value'] ]); ?></span>
+              <span><?php echo esc_html($star['append']); ?></span>
               </li>
             <?php endif; ?>
             <?php
@@ -44,8 +45,9 @@ function yesterdays_coffee_comment($comment, $args, $depth) {
               $amount_beans = get_field_object('amount-beans', $comment);
             ?>
               <li>
-              <span><?php echo $amount_beans['label']; ?></span>
-              <span><?php echo $amount_beans['value']; ?></span>
+              <span><?php echo esc_html($amount_beans['label']); ?></span>
+              <span><?php echo esc_html($amount_beans['value']); ?></span>
+              <span><?php echo esc_html($amount_beans['append']); ?></span>
               </li>
             <?php endif; ?>
             <?php
@@ -53,8 +55,9 @@ function yesterdays_coffee_comment($comment, $args, $depth) {
               $grind_size = get_field_object('grind-size', $comment);
             ?>
               <li>
-              <span><?php echo $grind_size['label']; ?></span>
-              <span><?php echo $grind_size['choices'][ $grind_size['value'] ]; ?></span>
+              <span><?php echo esc_html($grind_size['label']); ?></span>
+              <span><?php echo esc_html($grind_size['choices'][ $grind_size['value'] ]); ?></span>
+              <span><?php echo esc_html($grind_size['append']); ?></span>
               </li>
             <?php endif; ?>
             <?php
@@ -62,8 +65,9 @@ function yesterdays_coffee_comment($comment, $args, $depth) {
               $temperature = get_field_object('temperature', $comment);
             ?>
               <li>
-              <span><?php echo $temperature['label']; ?></span>
-              <span><?php echo $temperature['value']; ?></span>
+              <span><?php echo esc_html($temperature['label']); ?></span>
+              <span><?php echo esc_html($temperature['value']); ?></span>
+              <sup><?php echo esc_html($temperature['append']); ?></sup>
               </li>
             <?php endif; ?>
             <?php
@@ -71,8 +75,9 @@ function yesterdays_coffee_comment($comment, $args, $depth) {
               $extraction_time = get_field_object('extraction-time', $comment);
             ?>
               <li>
-              <span><?php echo $extraction_time['label']; ?></span>
-              <span><?php echo $extraction_time['value']; ?></span>
+              <span><?php echo esc_html($extraction_time['label']); ?></span>
+              <span><?php echo esc_html($extraction_time['value']); ?></span>
+              <span><?php echo esc_html($extraction_time['append']); ?></span>
               </li>
             <?php endif; ?>
             <?php
@@ -80,8 +85,9 @@ function yesterdays_coffee_comment($comment, $args, $depth) {
               $extraction_amount = get_field_object('extraction-amount', $comment);
             ?>
               <li>
-              <span><?php echo $extraction_amount['label']; ?></span>
-              <span><?php echo $extraction_amount['value']; ?></span>
+              <span><?php echo esc_html($extraction_amount['label']); ?></span>
+              <span><?php echo esc_html($extraction_amount['value']); ?></span>
+              <span><?php echo esc_html($extraction_amount['append']); ?></span>
               </li>
             <?php endif; ?>
             <?php
@@ -89,8 +95,9 @@ function yesterdays_coffee_comment($comment, $args, $depth) {
               $input_amount = get_field_object('input-amount', $comment);
             ?>
               <li>
-              <span><?php echo $input_amount['label']; ?></span>
-              <span><?php echo $input_amount['value']; ?></span>
+              <span><?php echo esc_html($input_amount['label']); ?></span>
+              <span><?php echo esc_html($input_amount['value']); ?></span>
+              <span><?php echo esc_html($input_amount['append']); ?></span>
               </li>
             <?php endif; ?>
             <?php
@@ -98,8 +105,9 @@ function yesterdays_coffee_comment($comment, $args, $depth) {
               $steaming_time = get_field_object('steaming-time', $comment);
             ?>
               <li>
-              <span><?php echo $steaming_time['label']; ?></span>
-              <span><?php echo $steaming_time['value']; ?></span>
+              <span><?php echo esc_html($steaming_time['label']); ?></span>
+              <span><?php echo esc_html($steaming_time['value']); ?></span>
+              <span><?php echo esc_html($steaming_time['append']); ?></span>
               </li>
             <?php endif; ?>
             </ul>

--- a/www/wp-content/themes/yesterdays-coffee/inc/custom-comment.php
+++ b/www/wp-content/themes/yesterdays-coffee/inc/custom-comment.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * yesterdays-coffee Theme Customizer comment
+ *
+ * @package yesterdays-coffee
+ */
+
+function yesterdays_coffee_comment($comment, $args, $depth) {
+    $GLOBALS['comment'] = $comment;
+    $tag = ( 'div' === $args['style'] ) ? 'div' : 'li';
+    $commenter = wp_get_current_commenter();
+    if ( $commenter['comment_author_email'] ) {
+        $moderation_note = __( 'Your comment is awaiting moderation.' );
+    } else {
+        $moderation_note = __( 'Your comment is awaiting moderation. This is a preview, your comment will be visible after it has been approved.' );
+    }
+    ?>
+    <<?php echo $tag; ?> id="comment-<?php comment_ID(); ?>" <?php comment_class( empty( $args['has_children'] ) ? 'parent' : '', $comment ); ?>>
+        <article id="div-comment-<?php comment_ID(); ?>" class="comment-body">
+            <footer class="comment-meta">
+                <div class="comment-author vcard">
+                    <?php
+                    if ( 0 != $args['avatar_size'] ) {
+                        echo get_avatar( $comment, $args['avatar_size'] );
+                    }
+                    ?>
+                    <?php
+                        printf(
+                            /* translators: %s: Comment author link. */
+                            __( '%s <span class="says">says:</span>' ),
+                            sprintf( '<b class="fn">%s</b>', get_comment_author_link( $comment ) )
+                        );
+                    ?>
+                </div><!-- .comment-author -->
+
+                <div class="comment-metadata">
+                    <a href="<?php echo esc_url( get_comment_link( $comment, $args ) ); ?>">
+                        <time datetime="<?php comment_time( 'c' ); ?>">
+                            <?php
+                                /* translators: 1: Comment date, 2: Comment time. */
+                                printf( __( '%1$s at %2$s' ), get_comment_date( '', $comment ), get_comment_time() );
+                            ?>
+                        </time>
+                    </a>
+                    <?php edit_comment_link( __( 'Edit' ), '<span class="edit-link">', '</span>' ); ?>
+                </div><!-- .comment-metadata -->
+
+                <?php if ( '0' == $comment->comment_approved ) : ?>
+                <em class="comment-awaiting-moderation"><?php echo $moderation_note; ?></em>
+                <?php endif; ?>
+            </footer><!-- .comment-meta -->
+
+            <div class="comment-content">
+                <?php comment_text(); ?>
+            </div><!-- .comment-content -->
+
+            <?php
+            comment_reply_link(
+                array_merge(
+                    $args,
+                    array(
+                        'add_below' => 'div-comment',
+                        'depth'     => $depth,
+                        'max_depth' => $args['max_depth'],
+                        'before'    => '<div class="reply">',
+                        'after'     => '</div>',
+                    )
+                )
+            );
+            ?>
+        </article><!-- .comment-body -->
+  <?php
+}

--- a/www/wp-content/themes/yesterdays-coffee/inc/custom-comment.php
+++ b/www/wp-content/themes/yesterdays-coffee/inc/custom-comment.php
@@ -8,31 +8,10 @@
 function yesterdays_coffee_comment($comment, $args, $depth) {
     $GLOBALS['comment'] = $comment;
     $tag = ( 'div' === $args['style'] ) ? 'div' : 'li';
-    $commenter = wp_get_current_commenter();
-    if ( $commenter['comment_author_email'] ) {
-        $moderation_note = __( 'Your comment is awaiting moderation.' );
-    } else {
-        $moderation_note = __( 'Your comment is awaiting moderation. This is a preview, your comment will be visible after it has been approved.' );
-    }
     ?>
     <<?php echo $tag; ?> id="comment-<?php comment_ID(); ?>" <?php comment_class( empty( $args['has_children'] ) ? 'parent' : '', $comment ); ?>>
         <article id="div-comment-<?php comment_ID(); ?>" class="comment-body">
             <footer class="comment-meta">
-                <div class="comment-author vcard">
-                    <?php
-                    if ( 0 != $args['avatar_size'] ) {
-                        echo get_avatar( $comment, $args['avatar_size'] );
-                    }
-                    ?>
-                    <?php
-                        printf(
-                            /* translators: %s: Comment author link. */
-                            __( '%s <span class="says">says:</span>' ),
-                            sprintf( '<b class="fn">%s</b>', get_comment_author_link( $comment ) )
-                        );
-                    ?>
-                </div><!-- .comment-author -->
-
                 <div class="comment-metadata">
                     <a href="<?php echo esc_url( get_comment_link( $comment, $args ) ); ?>">
                         <time datetime="<?php comment_time( 'c' ); ?>">
@@ -44,30 +23,11 @@ function yesterdays_coffee_comment($comment, $args, $depth) {
                     </a>
                     <?php edit_comment_link( __( 'Edit' ), '<span class="edit-link">', '</span>' ); ?>
                 </div><!-- .comment-metadata -->
-
-                <?php if ( '0' == $comment->comment_approved ) : ?>
-                <em class="comment-awaiting-moderation"><?php echo $moderation_note; ?></em>
-                <?php endif; ?>
             </footer><!-- .comment-meta -->
 
             <div class="comment-content">
                 <?php comment_text(); ?>
             </div><!-- .comment-content -->
-
-            <?php
-            comment_reply_link(
-                array_merge(
-                    $args,
-                    array(
-                        'add_below' => 'div-comment',
-                        'depth'     => $depth,
-                        'max_depth' => $args['max_depth'],
-                        'before'    => '<div class="reply">',
-                        'after'     => '</div>',
-                    )
-                )
-            );
-            ?>
         </article><!-- .comment-body -->
   <?php
 }

--- a/www/wp-content/themes/yesterdays-coffee/inc/custom-comment.php
+++ b/www/wp-content/themes/yesterdays-coffee/inc/custom-comment.php
@@ -29,89 +29,27 @@ function yesterdays_coffee_comment($comment, $args, $depth) {
                 <?php comment_text(); ?>
             </div><!-- .comment-content -->
 
-           <ul>
-           <?php
-            if ( get_field('star', $comment) ):
-              $star = get_field_object('star', $comment);
-            ?>
-              <li>
-              <span><?php echo esc_html($star['label']); ?></span>
-              <span><?php echo esc_html($star['choices'][ $star['value'] ]); ?></span>
-              <span><?php echo esc_html($star['append']); ?></span>
-              </li>
+            <?php $fields = get_fields($comment); if( $fields ): ?>
+                <ul>
+                    <?php foreach( $fields as $name => $value ): ?>
+                        <?php
+                            $field = get_field_object($name, $comment);
+                            $label = esc_html($field['label']);
+                            $unit = esc_html($field['append']);
+                            if ($field['type'] === 'select'){
+                                $val = esc_html($field['choices'][ $field['value'] ]);
+                            } else {
+                                $val = esc_html($field['value']);
+                            }
+                        ?>
+                        <li>
+                            <span><?php echo $label; ?></span>
+                            <span><?php echo $val; ?></span>
+                            <span><?php echo $unit; ?></span>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
             <?php endif; ?>
-            <?php
-            if ( get_field('amount-beans', $comment) ):
-              $amount_beans = get_field_object('amount-beans', $comment);
-            ?>
-              <li>
-              <span><?php echo esc_html($amount_beans['label']); ?></span>
-              <span><?php echo esc_html($amount_beans['value']); ?></span>
-              <span><?php echo esc_html($amount_beans['append']); ?></span>
-              </li>
-            <?php endif; ?>
-            <?php
-            if ( get_field('grind-size', $comment) ):
-              $grind_size = get_field_object('grind-size', $comment);
-            ?>
-              <li>
-              <span><?php echo esc_html($grind_size['label']); ?></span>
-              <span><?php echo esc_html($grind_size['choices'][ $grind_size['value'] ]); ?></span>
-              <span><?php echo esc_html($grind_size['append']); ?></span>
-              </li>
-            <?php endif; ?>
-            <?php
-            if ( get_field('temperature', $comment) ):
-              $temperature = get_field_object('temperature', $comment);
-            ?>
-              <li>
-              <span><?php echo esc_html($temperature['label']); ?></span>
-              <span><?php echo esc_html($temperature['value']); ?></span>
-              <sup><?php echo esc_html($temperature['append']); ?></sup>
-              </li>
-            <?php endif; ?>
-            <?php
-            if ( get_field('extraction-time', $comment) ):
-              $extraction_time = get_field_object('extraction-time', $comment);
-            ?>
-              <li>
-              <span><?php echo esc_html($extraction_time['label']); ?></span>
-              <span><?php echo esc_html($extraction_time['value']); ?></span>
-              <span><?php echo esc_html($extraction_time['append']); ?></span>
-              </li>
-            <?php endif; ?>
-            <?php
-            if ( get_field('extraction-amount', $comment) ):
-              $extraction_amount = get_field_object('extraction-amount', $comment);
-            ?>
-              <li>
-              <span><?php echo esc_html($extraction_amount['label']); ?></span>
-              <span><?php echo esc_html($extraction_amount['value']); ?></span>
-              <span><?php echo esc_html($extraction_amount['append']); ?></span>
-              </li>
-            <?php endif; ?>
-            <?php
-            if ( get_field('input-amount', $comment) ):
-              $input_amount = get_field_object('input-amount', $comment);
-            ?>
-              <li>
-              <span><?php echo esc_html($input_amount['label']); ?></span>
-              <span><?php echo esc_html($input_amount['value']); ?></span>
-              <span><?php echo esc_html($input_amount['append']); ?></span>
-              </li>
-            <?php endif; ?>
-            <?php
-            if ( get_field('steaming-time', $comment) ):
-              $steaming_time = get_field_object('steaming-time', $comment);
-            ?>
-              <li>
-              <span><?php echo esc_html($steaming_time['label']); ?></span>
-              <span><?php echo esc_html($steaming_time['value']); ?></span>
-              <span><?php echo esc_html($steaming_time['append']); ?></span>
-              </li>
-            <?php endif; ?>
-            </ul>
-
         </article><!-- .comment-body -->
   <?php
 }

--- a/www/wp-content/themes/yesterdays-coffee/inc/custom-comment.php
+++ b/www/wp-content/themes/yesterdays-coffee/inc/custom-comment.php
@@ -30,6 +30,15 @@ function yesterdays_coffee_comment($comment, $args, $depth) {
             </div><!-- .comment-content -->
 
            <ul>
+           <?php
+            if ( get_field('star', $comment) ):
+              $star = get_field_object('star', $comment);
+            ?>
+              <li>
+              <span><?php echo $star['label']; ?></span>
+              <span><?php echo $star['choices'][ $star['value'] ]; ?></span>
+              </li>
+            <?php endif; ?>
             <?php
             if ( get_field('amount-beans', $comment) ):
               $amount_beans = get_field_object('amount-beans', $comment);


### PR DESCRIPTION
# 概要
ハンドドリップの記録をつけるために、コメント欄を拡張します。

# 詳細
項目は[コーヒーレシピ記録アプリ『Kopi』使いはじめました【プロのコーヒーレシピ】](https://note.com/satyyyyy/n/n9979cded19d0)を参考にします。

コメント欄の拡張は、[Advanced Custom Fields](https://www.advancedcustomfields.co)を導入して拡張します。

## フィールド設定

フィールドグループ名：コーヒーのコメント

|順序|ラベル|名前|タイプ|
|--|--|--|--|
|1|評価|rating|Select|
|2|豆の量(g)|beans-weight |数値|
|3|豆の粗さ|grind-size|Select|
|4|水温(°C)|water-temp|数値|
|5|抽出時間(秒)|extraction-time|数値|
|6|抽出量(ml)|extraction-amount|数値|
|7|投入量(g)|input-amount|数値|
|8|蒸らし時間(秒)|steaming-time|数値|

### Select詳細
#### 評価

|ラベル|名前|デフォルト|
|--|--|--|
|1|★||
|2|★★||
|3|★★★|○|
|4|★★★★||
|5|★★★★★||

#### 豆の粗さ

|ラベル|名前|デフォルト|
|--|--|--|
|coarse|粗挽き||
|medium|中挽き|○|
|fine|細挽き||

## コメントの表示
Advanced Custom Fieldsで登録された項目を表示するために、`wp_list_comments`の`callback`を使用する。
そのまま使用するとデフォルトがなくなるので、[`Walker_Comment::html5_comment()`](https://developer.wordpress.org/reference/classes/walker_comment/html5_comment/) のコピーしてデフォルトで表示される項目を表示させる。

[How to get values from a comment](https://www.advancedcustomfields.com/resources/get-values-comment/)をみてAdvanced Custom Fieldsで登録された項目を表示させる。